### PR TITLE
Extend parser for variables and arithmetic verbs

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,25 +5,74 @@ import (
 	"strings"
 )
 
+// Program represents a parsed COBOL program.  It contains a list of
+// statements in the PROCEDURE DIVISION as well as a simple symbol table of
+// working-storage data items.
 type Program struct {
-	Statements []Statement
+	Statements  []Statement
+	SymbolTable map[string]*DataItem
 }
 
+// Statement is implemented by all COBOL statements that the parser
+// recognizes.  The parser is intentionally minimal and only understands a
+// handful of arithmetic verbs and DISPLAY/STOP.
 type Statement interface{}
 
-type Display struct {
-	Value string
+// DataItem represents a variable declared in the DATA DIVISION.
+type DataItem struct {
+	Name string
 }
+
+// Display corresponds to the DISPLAY statement.  Either Value (for string
+// literals) or Identifier is set.
+type Display struct {
+	Value      string
+	Identifier string
+}
+
+// The remaining structs represent arithmetic and move style verbs.  For the
+// purposes of this project they simply record the identifiers that appear in
+// the statement in the order they were encountered.
+type Move struct{ Operands []string }
+type Add struct{ Operands []string }
+type Subtract struct{ Operands []string }
+type Multiply struct{ Operands []string }
+type Divide struct{ Operands []string }
+type Compute struct{ Operands []string }
+type Initialize struct{ Operands []string }
 
 type Stop struct{}
 
+// Parse performs a very small amount of COBOL parsing sufficient for unit
+// tests.  It recognises DATA DIVISION/WORKING-STORAGE declarations and a small
+// subset of PROCEDURE DIVISION statements containing identifiers.
 func Parse(src string) (*Program, error) {
-	p := &Program{}
+	p := &Program{SymbolTable: make(map[string]*DataItem)}
 	scanner := bufio.NewScanner(strings.NewReader(src))
+	inWorking := false
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		line = strings.TrimSuffix(line, ".")
 		lineUpper := strings.ToUpper(line)
+
+		switch {
+		case lineUpper == "DATA DIVISION" || lineUpper == "WORKING-STORAGE SECTION":
+			inWorking = true
+			continue
+		case lineUpper == "PROCEDURE DIVISION":
+			inWorking = false
+			continue
+		}
+
+		if inWorking {
+			fields := strings.Fields(lineUpper)
+			if len(fields) >= 2 {
+				name := fields[1]
+				p.SymbolTable[name] = &DataItem{Name: name}
+			}
+			continue
+		}
+
 		switch {
 		case strings.HasPrefix(lineUpper, "DISPLAY "):
 			start := strings.Index(line, "\"")
@@ -31,10 +80,53 @@ func Parse(src string) (*Program, error) {
 			if start >= 0 && end > start {
 				value := line[start+1 : end]
 				p.Statements = append(p.Statements, &Display{Value: value})
+			} else {
+				parts := strings.Fields(line)
+				if len(parts) > 1 {
+					p.Statements = append(p.Statements, &Display{Identifier: parts[1]})
+				}
 			}
+		case strings.HasPrefix(lineUpper, "MOVE "):
+			p.Statements = append(p.Statements, &Move{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "ADD "):
+			p.Statements = append(p.Statements, &Add{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "SUBTRACT "):
+			p.Statements = append(p.Statements, &Subtract{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "MULTIPLY "):
+			p.Statements = append(p.Statements, &Multiply{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "DIVIDE "):
+			p.Statements = append(p.Statements, &Divide{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "COMPUTE "):
+			p.Statements = append(p.Statements, &Compute{Operands: parseOperands(line)})
+		case strings.HasPrefix(lineUpper, "INITIALIZE "):
+			p.Statements = append(p.Statements, &Initialize{Operands: parseOperands(line)})
 		case lineUpper == "STOP RUN":
 			p.Statements = append(p.Statements, &Stop{})
 		}
 	}
 	return p, scanner.Err()
+}
+
+// parseOperands extracts identifiers from a statement line by removing common
+// punctuation and keywords.  It is intentionally permissive and is only meant
+// for tests.
+func parseOperands(line string) []string {
+	tokens := strings.Fields(strings.TrimSuffix(line, "."))
+	operands := []string{}
+	for _, tok := range tokens[1:] { // skip verb
+		upper := strings.ToUpper(tok)
+		if upper == "TO" || upper == "FROM" || upper == "BY" || upper == "INTO" || upper == "GIVING" || upper == "=" {
+			continue
+		}
+		// split on arithmetic operators
+		parts := strings.FieldsFunc(tok, func(r rune) bool {
+			return strings.ContainsRune("+-*/", r)
+		})
+		for _, p := range parts {
+			if p != "" {
+				operands = append(operands, p)
+			}
+		}
+	}
+	return operands
 }

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -26,3 +26,77 @@ func TestParseHelloWorld(t *testing.T) {
 		t.Fatalf("expected STOP statement")
 	}
 }
+
+// TestParseOperations verifies parsing of a small subset of COBOL syntax such as
+// DATA DIVISION declarations and arithmetic verbs with identifiers.
+func TestParseOperations(t *testing.T) {
+	src := `DATA DIVISION.
+WORKING-STORAGE SECTION.
+01 A.
+01 B.
+01 C.
+PROCEDURE DIVISION.
+DISPLAY "START".
+MOVE A TO B.
+ADD A TO B.
+SUBTRACT A FROM B.
+MULTIPLY A BY B.
+DIVIDE A INTO B.
+COMPUTE A = B + C.
+INITIALIZE A B.
+DISPLAY A.
+STOP RUN.`
+
+	prog, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(prog.SymbolTable) != 3 {
+		t.Fatalf("expected 3 data items, got %d", len(prog.SymbolTable))
+	}
+
+	if len(prog.Statements) != 10 {
+		t.Fatalf("expected 10 statements, got %d", len(prog.Statements))
+	}
+
+	if d, ok := prog.Statements[0].(*parser.Display); !ok || d.Value != "START" {
+		t.Fatalf("expected first DISPLAY 'START'")
+	}
+
+	if mv, ok := prog.Statements[1].(*parser.Move); !ok || len(mv.Operands) != 2 {
+		t.Fatalf("expected MOVE with two operands")
+	}
+
+	if ad, ok := prog.Statements[2].(*parser.Add); !ok || len(ad.Operands) != 2 {
+		t.Fatalf("expected ADD with two operands")
+	}
+
+	if sb, ok := prog.Statements[3].(*parser.Subtract); !ok || len(sb.Operands) != 2 {
+		t.Fatalf("expected SUBTRACT with two operands")
+	}
+
+	if ml, ok := prog.Statements[4].(*parser.Multiply); !ok || len(ml.Operands) != 2 {
+		t.Fatalf("expected MULTIPLY with two operands")
+	}
+
+	if dv, ok := prog.Statements[5].(*parser.Divide); !ok || len(dv.Operands) != 2 {
+		t.Fatalf("expected DIVIDE with two operands")
+	}
+
+	if cp, ok := prog.Statements[6].(*parser.Compute); !ok || len(cp.Operands) != 3 {
+		t.Fatalf("expected COMPUTE with three operands")
+	}
+
+	if init, ok := prog.Statements[7].(*parser.Initialize); !ok || len(init.Operands) != 2 {
+		t.Fatalf("expected INITIALIZE with two operands")
+	}
+
+	if d, ok := prog.Statements[8].(*parser.Display); !ok || d.Identifier != "A" {
+		t.Fatalf("expected DISPLAY of identifier A")
+	}
+
+	if _, ok := prog.Statements[9].(*parser.Stop); !ok {
+		t.Fatalf("expected STOP statement")
+	}
+}


### PR DESCRIPTION
## Summary
- add DataItem and arithmetic verb nodes to AST
- parse DATA DIVISION/WORKING-STORAGE and fill a symbol table
- support identifiers in COMPUTE, DIVIDE, MULTIPLY, SUBTRACT, ADD, MOVE, INITIALIZE, and DISPLAY

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895a2bc6a98832b94f7e44b1b7b7cd9