### PR TITLE
Add arithmetic verb support and examples

### DIFF
--- a/examples/verbs.cob
+++ b/examples/verbs.cob
@@ -1,0 +1,16 @@
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. VERBS.
+
+       PROCEDURE DIVISION.
+           DISPLAY "START".
+           MOVE 5 TO A.
+           ADD 3 TO A.
+           SUBTRACT 2 FROM A.
+           MULTIPLY A BY 2.
+           DIVIDE A BY 3.
+           COMPUTE B = A + 1.
+           INITIALIZE C.
+           DISPLAY A.
+           DISPLAY B.
+           DISPLAY C.
+           STOP RUN.

--- a/examples/verbs.java
+++ b/examples/verbs.java
@@ -1,0 +1,15 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("START");
+        int A = 5;
+        A = A + 3;
+        A = A - 2;
+        A = A * 2;
+        A = A / 3;
+        int B = A + 1;
+        int C = 0;
+        System.out.println(A);
+        System.out.println(B);
+        System.out.println(C);
+    }
+}

--- a/examples/verbs.py
+++ b/examples/verbs.py
@@ -1,0 +1,11 @@
+print("START")
+A = 5
+A = A + 3
+A = A - 2
+A = A * 2
+A = A / 3
+B = A + 1
+C = 0
+print(A)
+print(B)
+print(C)

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -9,7 +9,47 @@ type Program struct {
 type Op interface{}
 
 type Display struct {
-	Value string
+	Value     string
+	IsLiteral bool
+}
+
+type Move struct {
+	From        string
+	FromLiteral bool
+	To          string
+}
+
+type Add struct {
+	Value   string
+	Literal bool
+	To      string
+}
+
+type Subtract struct {
+	Value   string
+	Literal bool
+	From    string
+}
+
+type Multiply struct {
+	Variable string
+	Value    string
+	Literal  bool
+}
+
+type Divide struct {
+	Variable string
+	Value    string
+	Literal  bool
+}
+
+type Compute struct {
+	Target string
+	Expr   string
+}
+
+type Initialize struct {
+	Variable string
 }
 
 type Stop struct{}
@@ -19,7 +59,21 @@ func FromAST(p *parser.Program) *Program {
 	for _, stmt := range p.Statements {
 		switch s := stmt.(type) {
 		case *parser.Display:
-			irp.Ops = append(irp.Ops, &Display{Value: s.Value})
+			irp.Ops = append(irp.Ops, &Display{Value: s.Value, IsLiteral: s.IsLiteral})
+		case *parser.Move:
+			irp.Ops = append(irp.Ops, &Move{From: s.From, FromLiteral: s.FromLiteral, To: s.To})
+		case *parser.Add:
+			irp.Ops = append(irp.Ops, &Add{Value: s.Value, Literal: s.Literal, To: s.To})
+		case *parser.Subtract:
+			irp.Ops = append(irp.Ops, &Subtract{Value: s.Value, Literal: s.Literal, From: s.From})
+		case *parser.Multiply:
+			irp.Ops = append(irp.Ops, &Multiply{Variable: s.Variable, Value: s.Value, Literal: s.Literal})
+		case *parser.Divide:
+			irp.Ops = append(irp.Ops, &Divide{Variable: s.Variable, Value: s.Value, Literal: s.Literal})
+		case *parser.Compute:
+			irp.Ops = append(irp.Ops, &Compute{Target: s.Target, Expr: s.Expr})
+		case *parser.Initialize:
+			irp.Ops = append(irp.Ops, &Initialize{Variable: s.Variable})
 		case *parser.Stop:
 			irp.Ops = append(irp.Ops, &Stop{})
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"strconv"
 	"strings"
 )
 
@@ -12,7 +13,47 @@ type Program struct {
 type Statement interface{}
 
 type Display struct {
-	Value string
+	Value     string
+	IsLiteral bool
+}
+
+type Move struct {
+	From        string
+	FromLiteral bool
+	To          string
+}
+
+type Add struct {
+	Value   string
+	Literal bool
+	To      string
+}
+
+type Subtract struct {
+	Value   string
+	Literal bool
+	From    string
+}
+
+type Multiply struct {
+	Variable string
+	Value    string
+	Literal  bool
+}
+
+type Divide struct {
+	Variable string
+	Value    string
+	Literal  bool
+}
+
+type Compute struct {
+	Target string
+	Expr   string
+}
+
+type Initialize struct {
+	Variable string
 }
 
 type Stop struct{}
@@ -26,11 +67,65 @@ func Parse(src string) (*Program, error) {
 		lineUpper := strings.ToUpper(line)
 		switch {
 		case strings.HasPrefix(lineUpper, "DISPLAY "):
-			start := strings.Index(line, "\"")
-			end := strings.LastIndex(line, "\"")
-			if start >= 0 && end > start {
-				value := line[start+1 : end]
-				p.Statements = append(p.Statements, &Display{Value: value})
+			rest := strings.TrimSpace(line[8:])
+			if strings.HasPrefix(rest, "\"") && strings.HasSuffix(rest, "\"") {
+				value := rest[1 : len(rest)-1]
+				p.Statements = append(p.Statements, &Display{Value: value, IsLiteral: true})
+			} else if rest != "" {
+				p.Statements = append(p.Statements, &Display{Value: rest})
+			}
+		case strings.HasPrefix(lineUpper, "MOVE "):
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.ToUpper(parts[2]) == "TO" {
+				from := parts[1]
+				to := parts[3]
+				_, err := strconv.Atoi(from)
+				p.Statements = append(p.Statements, &Move{From: from, FromLiteral: err == nil, To: to})
+			}
+		case strings.HasPrefix(lineUpper, "ADD "):
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.ToUpper(parts[2]) == "TO" {
+				val := parts[1]
+				to := parts[3]
+				_, err := strconv.Atoi(val)
+				p.Statements = append(p.Statements, &Add{Value: val, Literal: err == nil, To: to})
+			}
+		case strings.HasPrefix(lineUpper, "SUBTRACT "):
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.ToUpper(parts[2]) == "FROM" {
+				val := parts[1]
+				from := parts[3]
+				_, err := strconv.Atoi(val)
+				p.Statements = append(p.Statements, &Subtract{Value: val, Literal: err == nil, From: from})
+			}
+		case strings.HasPrefix(lineUpper, "MULTIPLY "):
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.ToUpper(parts[2]) == "BY" {
+				variable := parts[1]
+				val := parts[3]
+				_, err := strconv.Atoi(val)
+				p.Statements = append(p.Statements, &Multiply{Variable: variable, Value: val, Literal: err == nil})
+			}
+		case strings.HasPrefix(lineUpper, "DIVIDE "):
+			parts := strings.Fields(line)
+			if len(parts) >= 4 && strings.ToUpper(parts[2]) == "BY" {
+				variable := parts[1]
+				val := parts[3]
+				_, err := strconv.Atoi(val)
+				p.Statements = append(p.Statements, &Divide{Variable: variable, Value: val, Literal: err == nil})
+			}
+		case strings.HasPrefix(lineUpper, "COMPUTE "):
+			rest := strings.TrimSpace(line[8:])
+			parts := strings.SplitN(rest, "=", 2)
+			if len(parts) == 2 {
+				target := strings.TrimSpace(parts[0])
+				expr := strings.TrimSpace(parts[1])
+				p.Statements = append(p.Statements, &Compute{Target: target, Expr: expr})
+			}
+		case strings.HasPrefix(lineUpper, "INITIALIZE "):
+			variable := strings.TrimSpace(line[10:])
+			if variable != "" {
+				p.Statements = append(p.Statements, &Initialize{Variable: variable})
 			}
 		case lineUpper == "STOP RUN":
 			p.Statements = append(p.Statements, &Stop{})

--- a/tests/ir_test.go
+++ b/tests/ir_test.go
@@ -28,3 +28,54 @@ func TestIRConversion(t *testing.T) {
 		t.Fatalf("expected STOP op")
 	}
 }
+
+func TestIRVerbs(t *testing.T) {
+	src, err := os.ReadFile("../examples/verbs.cob")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	prog, err := parser.Parse(string(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	irp := ir.FromAST(prog)
+	if len(irp.Ops) != 12 {
+		t.Fatalf("expected 12 ops, got %d", len(irp.Ops))
+	}
+	if d, ok := irp.Ops[0].(*ir.Display); !ok || d.Value != "START" || !d.IsLiteral {
+		t.Fatalf("expected DISPLAY literal 'START'")
+	}
+	if m, ok := irp.Ops[1].(*ir.Move); !ok || m.From != "5" || m.To != "A" {
+		t.Fatalf("expected MOVE 5 TO A")
+	}
+	if a, ok := irp.Ops[2].(*ir.Add); !ok || a.Value != "3" || a.To != "A" {
+		t.Fatalf("expected ADD 3 TO A")
+	}
+	if s, ok := irp.Ops[3].(*ir.Subtract); !ok || s.Value != "2" || s.From != "A" {
+		t.Fatalf("expected SUBTRACT 2 FROM A")
+	}
+	if mu, ok := irp.Ops[4].(*ir.Multiply); !ok || mu.Variable != "A" || mu.Value != "2" {
+		t.Fatalf("expected MULTIPLY A BY 2")
+	}
+	if d, ok := irp.Ops[5].(*ir.Divide); !ok || d.Variable != "A" || d.Value != "3" {
+		t.Fatalf("expected DIVIDE A BY 3")
+	}
+	if c, ok := irp.Ops[6].(*ir.Compute); !ok || c.Target != "B" || c.Expr != "A + 1" {
+		t.Fatalf("expected COMPUTE B = A + 1")
+	}
+	if i, ok := irp.Ops[7].(*ir.Initialize); !ok || i.Variable != "C" {
+		t.Fatalf("expected INITIALIZE C")
+	}
+	if d, ok := irp.Ops[8].(*ir.Display); !ok || d.Value != "A" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY A")
+	}
+	if d, ok := irp.Ops[9].(*ir.Display); !ok || d.Value != "B" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY B")
+	}
+	if d, ok := irp.Ops[10].(*ir.Display); !ok || d.Value != "C" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY C")
+	}
+	if _, ok := irp.Ops[11].(*ir.Stop); !ok {
+		t.Fatalf("expected STOP op")
+	}
+}

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -26,3 +26,53 @@ func TestParseHelloWorld(t *testing.T) {
 		t.Fatalf("expected STOP statement")
 	}
 }
+
+func TestParseVerbs(t *testing.T) {
+	src, err := os.ReadFile("../examples/verbs.cob")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	prog, err := parser.Parse(string(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(prog.Statements) != 12 {
+		t.Fatalf("expected 12 statements, got %d", len(prog.Statements))
+	}
+	if d, ok := prog.Statements[0].(*parser.Display); !ok || d.Value != "START" || !d.IsLiteral {
+		t.Fatalf("expected DISPLAY literal 'START'")
+	}
+	if m, ok := prog.Statements[1].(*parser.Move); !ok || m.From != "5" || m.To != "A" {
+		t.Fatalf("expected MOVE 5 TO A")
+	}
+	if a, ok := prog.Statements[2].(*parser.Add); !ok || a.Value != "3" || a.To != "A" {
+		t.Fatalf("expected ADD 3 TO A")
+	}
+	if s, ok := prog.Statements[3].(*parser.Subtract); !ok || s.Value != "2" || s.From != "A" {
+		t.Fatalf("expected SUBTRACT 2 FROM A")
+	}
+	if mu, ok := prog.Statements[4].(*parser.Multiply); !ok || mu.Variable != "A" || mu.Value != "2" {
+		t.Fatalf("expected MULTIPLY A BY 2")
+	}
+	if d, ok := prog.Statements[5].(*parser.Divide); !ok || d.Variable != "A" || d.Value != "3" {
+		t.Fatalf("expected DIVIDE A BY 3")
+	}
+	if c, ok := prog.Statements[6].(*parser.Compute); !ok || c.Target != "B" || c.Expr != "A + 1" {
+		t.Fatalf("expected COMPUTE B = A + 1")
+	}
+	if i, ok := prog.Statements[7].(*parser.Initialize); !ok || i.Variable != "C" {
+		t.Fatalf("expected INITIALIZE C")
+	}
+	if d, ok := prog.Statements[8].(*parser.Display); !ok || d.Value != "A" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY A")
+	}
+	if d, ok := prog.Statements[9].(*parser.Display); !ok || d.Value != "B" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY B")
+	}
+	if d, ok := prog.Statements[10].(*parser.Display); !ok || d.Value != "C" || d.IsLiteral {
+		t.Fatalf("expected DISPLAY C")
+	}
+	if _, ok := prog.Statements[11].(*parser.Stop); !ok {
+		t.Fatalf("expected STOP statement")
+	}
+}

--- a/tests/translator_test.go
+++ b/tests/translator_test.go
@@ -43,3 +43,37 @@ func TestJavaTranslation(t *testing.T) {
 		t.Fatalf("java translation mismatch:\nexpected:\n%q\nactual:\n%q", string(expected), out)
 	}
 }
+
+func TestPythonTranslationVerbs(t *testing.T) {
+	src, err := os.ReadFile("../examples/verbs.cob")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	prog, _ := parser.Parse(string(src))
+	irp := ir.FromAST(prog)
+	out := pyt.Translate(irp)
+	expected, err := os.ReadFile("../examples/verbs.py")
+	if err != nil {
+		t.Fatalf("read python example: %v", err)
+	}
+	if out != string(expected) {
+		t.Fatalf("python translation mismatch:\nexpected:\n%q\nactual:\n%q", string(expected), out)
+	}
+}
+
+func TestJavaTranslationVerbs(t *testing.T) {
+	src, err := os.ReadFile("../examples/verbs.cob")
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	prog, _ := parser.Parse(string(src))
+	irp := ir.FromAST(prog)
+	out := javat.Translate(irp)
+	expected, err := os.ReadFile("../examples/verbs.java")
+	if err != nil {
+		t.Fatalf("read java example: %v", err)
+	}
+	if out != string(expected) {
+		t.Fatalf("java translation mismatch:\nexpected:\n%q\nactual:\n%q", string(expected), out)
+	}
+}

--- a/translator/java/java.go
+++ b/translator/java/java.go
@@ -9,12 +9,109 @@ func Translate(p *ir.Program) string {
 	var b strings.Builder
 	b.WriteString("public class Main {\n")
 	b.WriteString("    public static void main(String[] args) {\n")
+	declared := map[string]bool{}
 	for _, op := range p.Ops {
 		switch o := op.(type) {
 		case *ir.Display:
-			b.WriteString("        System.out.println(\"")
+			if o.IsLiteral {
+				b.WriteString("        System.out.println(\"")
+				b.WriteString(o.Value)
+				b.WriteString("\");\n")
+			} else {
+				b.WriteString("        System.out.println(")
+				b.WriteString(o.Value)
+				b.WriteString(");\n")
+			}
+		case *ir.Move:
+			if !declared[o.To] {
+				b.WriteString("        int ")
+				b.WriteString(o.To)
+				declared[o.To] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.To)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.From)
+			b.WriteString(";\n")
+		case *ir.Add:
+			if !declared[o.To] {
+				b.WriteString("        int ")
+				b.WriteString(o.To)
+				declared[o.To] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.To)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.To)
+			b.WriteString(" + ")
 			b.WriteString(o.Value)
-			b.WriteString("\");\n")
+			b.WriteString(";\n")
+		case *ir.Subtract:
+			if !declared[o.From] {
+				b.WriteString("        int ")
+				b.WriteString(o.From)
+				declared[o.From] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.From)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.From)
+			b.WriteString(" - ")
+			b.WriteString(o.Value)
+			b.WriteString(";\n")
+		case *ir.Multiply:
+			if !declared[o.Variable] {
+				b.WriteString("        int ")
+				b.WriteString(o.Variable)
+				declared[o.Variable] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.Variable)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.Variable)
+			b.WriteString(" * ")
+			b.WriteString(o.Value)
+			b.WriteString(";\n")
+		case *ir.Divide:
+			if !declared[o.Variable] {
+				b.WriteString("        int ")
+				b.WriteString(o.Variable)
+				declared[o.Variable] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.Variable)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.Variable)
+			b.WriteString(" / ")
+			b.WriteString(o.Value)
+			b.WriteString(";\n")
+		case *ir.Compute:
+			if !declared[o.Target] {
+				b.WriteString("        int ")
+				b.WriteString(o.Target)
+				declared[o.Target] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.Target)
+			}
+			b.WriteString(" = ")
+			b.WriteString(o.Expr)
+			b.WriteString(";\n")
+		case *ir.Initialize:
+			if !declared[o.Variable] {
+				b.WriteString("        int ")
+				b.WriteString(o.Variable)
+				declared[o.Variable] = true
+			} else {
+				b.WriteString("        ")
+				b.WriteString(o.Variable)
+			}
+			b.WriteString(" = 0;\n")
 		}
 	}
 	b.WriteString("    }\n}\n")

--- a/translator/python/python.go
+++ b/translator/python/python.go
@@ -10,9 +10,56 @@ func Translate(p *ir.Program) string {
 	for _, op := range p.Ops {
 		switch o := op.(type) {
 		case *ir.Display:
-			b.WriteString("print(\"")
+			if o.IsLiteral {
+				b.WriteString("print(\"")
+				b.WriteString(o.Value)
+				b.WriteString("\")\n")
+			} else {
+				b.WriteString("print(")
+				b.WriteString(o.Value)
+				b.WriteString(")\n")
+			}
+		case *ir.Move:
+			b.WriteString(o.To)
+			b.WriteString(" = ")
+			b.WriteString(o.From)
+			b.WriteString("\n")
+		case *ir.Add:
+			b.WriteString(o.To)
+			b.WriteString(" = ")
+			b.WriteString(o.To)
+			b.WriteString(" + ")
 			b.WriteString(o.Value)
-			b.WriteString("\")\n")
+			b.WriteString("\n")
+		case *ir.Subtract:
+			b.WriteString(o.From)
+			b.WriteString(" = ")
+			b.WriteString(o.From)
+			b.WriteString(" - ")
+			b.WriteString(o.Value)
+			b.WriteString("\n")
+		case *ir.Multiply:
+			b.WriteString(o.Variable)
+			b.WriteString(" = ")
+			b.WriteString(o.Variable)
+			b.WriteString(" * ")
+			b.WriteString(o.Value)
+			b.WriteString("\n")
+		case *ir.Divide:
+			b.WriteString(o.Variable)
+			b.WriteString(" = ")
+			b.WriteString(o.Variable)
+			b.WriteString(" / ")
+			b.WriteString(o.Value)
+			b.WriteString("\n")
+		case *ir.Compute:
+			b.WriteString(o.Target)
+			b.WriteString(" = ")
+			b.WriteString(o.Expr)
+			b.WriteString("\n")
+		case *ir.Initialize:
+			b.WriteString(o.Variable)
+			b.WriteString(" = 0\n")
 		}
 	}
 	return b.String()


### PR DESCRIPTION
## Summary
- add example using arithmetic verbs and matching Python/Java translations
- extend parser, IR, and translators for MOVE, ADD, SUBTRACT, MULTIPLY, DIVIDE, COMPUTE, INITIALIZE, and variable DISPLAY
- test parsing, IR conversion, and translations for the new verbs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895a2c0e460832b80493701a8073a3d